### PR TITLE
Erb support

### DIFF
--- a/lib/simple_websocket_vcr.rb
+++ b/lib/simple_websocket_vcr.rb
@@ -69,9 +69,14 @@ module WebSocketVCR
   def save_session
   end
 
-  def use_cassette(name, _options = {})
+  # Use the specified cassette for either recording the real communication or replaying it during the tests.
+  # @param name [String] the cassette
+  # @param options [Hash] options for the cassette
+  # @option options [Symbol] :record if set to :none there will be no recording
+  # @option options [Symbol] :erb a sub-hash with variables used for ERB substitution in given cassette
+  def use_cassette(name, options = {})
     fail ArgumentError, '`VCR.use_cassette` requires a block.' unless block_given?
-    self.cassette = Cassette.new(name)
+    self.cassette = Cassette.new(name, options)
     yield
     cassette.save
     self.cassette = nil

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_yaml_cassette.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_yaml_cassette.yml
@@ -2,7 +2,7 @@
 websocket_interactions:
 - - operation: read
     type: text
-    data: WelcomeResponse={"sessionId":"Wk5AgRVBjxWhBIihLTxsA3IjZkpZoAlhJP6mHsiP"}
+    data: WelcomeResponse={"sessionId":"<%= foobar %>"}
   - operation: write
     data: something_1
   - operation: read

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.json
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.json
@@ -1,0 +1,13 @@
+[
+  [
+    {
+      "operation": "read",
+      "type": "text",
+      "data": "WelcomeResponse={\"<%= something %>\":\"I_XSiCb1wcQgARIzJ_jRU8k2-kPVblJuNCxhYBnb\"}"
+    },
+    {
+      "operation": "write",
+      "data": "<%= bar %>"
+    }
+  ]
+]

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.yml
@@ -1,0 +1,25 @@
+---
+websocket_interactions:
+- - operation: read
+    type: text
+    data: WelcomeResponse={"<%= something %>":"KOrViCF_93axNx-WyGlhT6yktwqbJIl97mrxQXC5"}
+  - operation: write
+    data: something_1
+  - operation: read
+    type: text
+    data: 'GenericErrorResponse={"errorMessage":"Failed to process message [?]","stackTrace":"java.lang.IllegalArgumentException:
+      Cannot deserialize: [something_1]\n\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\n\tat
+      org.hawkular.cmdgw.api.ApiDeserializer.deserialize(ApiDeserializer.java:84)\n\tat
+      org.hawkular.cmdgw.command.ws.server.AbstractGatewayWebSocket.onMessage(AbstractGatewayWebSocket.java:213)\n\tat
+      sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat
+      sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat
+      java.lang.reflect.Method.invoke(Method.java:497)\n\tat io.undertow.websockets.jsr.annotated.BoundMethod.invoke(BoundMethod.java:87)\n\tat
+      io.undertow.websockets.jsr.annotated.AnnotatedEndpoint$2$1.run(AnnotatedEndpoint.java:150)\n\tat
+      io.undertow.websockets.jsr.ServerWebSocketContainer.invokeEndpointMethod(ServerWebSocketContainer.java:553)\n\tat
+      io.undertow.websockets.jsr.annotated.AnnotatedEndpoint$2.onMessage(AnnotatedEndpoint.java:145)\n\tat
+      io.undertow.websockets.jsr.FrameHandler$7.run(FrameHandler.java:283)\n\tat io.undertow.websockets.jsr.ServerWebSocketContainer.invokeEndpointMethod(ServerWebSocketContainer.java:553)\n\tat
+      io.undertow.websockets.jsr.ServerWebSocketContainer$5.run(ServerWebSocketContainer.java:538)\n\tat
+      io.undertow.websockets.jsr.OrderedExecutor$ExecutorTask.run(OrderedExecutor.java:67)\n\tat
+      java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\n\tat
+      java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\tat
+      java.lang.Thread.run(Thread.java:745)\n"}'

--- a/spec/vcr_spec.rb
+++ b/spec/vcr_spec.rb
@@ -229,7 +229,7 @@ describe 'VCR for WS' do
       prefix = WebSocketVCR.configuration.cassette_library_dir
       cassette_path = '/EXPLICIT/something_nonexistent'
       expect do
-        WebSocketVCR.use_cassette(cassette_path, {record: :none}) do
+        WebSocketVCR.use_cassette(cassette_path, record: :none) do
           fail 'this code should not be reachable'
         end
       end.to raise_error(RuntimeError)
@@ -256,7 +256,7 @@ describe 'VCR for WS' do
       WebSocketVCR.configure do |c|
         c.hook_uris = [HOST]
       end
-      WebSocketVCR.use_cassette(cassette_path, {erb: {something: 11223344}}) do
+      WebSocketVCR.use_cassette(cassette_path, erb: { something: 11_223_344 }) do
         test_substitution '11223344'
       end
       file_path = "#{WebSocketVCR.configuration.cassette_library_dir}#{cassette_path}.yml"
@@ -269,7 +269,7 @@ describe 'VCR for WS' do
         c.hook_uris = [HOST]
         c.json_cassettes = true
       end
-      WebSocketVCR.use_cassette(cassette_path, {erb: {something: 'world', bar: 'hello'}}) do
+      WebSocketVCR.use_cassette(cassette_path, erb: { something: 'world', bar: 'hello' }) do
         test_substitution 'world', 'hello'
       end
     end

--- a/spec/vcr_spec.rb
+++ b/spec/vcr_spec.rb
@@ -218,5 +218,60 @@ describe 'VCR for WS' do
         WebSocketVCR.configure { |c| c.hook_uris = ['127.0.0.1:1337'] }
       end.to change { WebSocketVCR.configuration.hook_uris }.from([]).to(['127.0.0.1:1337'])
     end
+
+    it 'has an empty list of hook ports by default' do
+      expect(WebSocketVCR.configuration.hook_uris).to eq([])
+    end
+  end
+
+  context 'with cassette options' do
+    it 'with :record set to :none and no cassette, it should fail' do
+      prefix = WebSocketVCR.configuration.cassette_library_dir
+      cassette_path = '/EXPLICIT/something_nonexistent'
+      expect do
+        WebSocketVCR.use_cassette(cassette_path, {record: :none}) do
+          fail 'this code should not be reachable'
+        end
+      end.to raise_error(RuntimeError)
+      expect(File.exist?(prefix + cassette_path + '.yml')).to be false
+    end
+
+    def test_substitution(text1, text2 = nil)
+      url = "ws://#{HOST}/hawkular/command-gateway/ui/ws"
+      c = WebSocket::Client::Simple.connect url do |client|
+        client.on(:message, once: true) do |msg|
+          expect(msg.data).to include(text1)
+        end
+      end
+      sleep 1 if should_sleep
+      text2 ||= 'something_1'
+      c.send(text2)
+      c.on(:message, once: true) do |msg|
+        expect(msg.data).to include("Cannot deserialize: [#{text2}]")
+      end
+    end
+
+    it 'with :erb set to {something: 11223344}, it should replace the variable in yaml cassette' do
+      cassette_path = '/EXPLICIT/some_template'
+      WebSocketVCR.configure do |c|
+        c.hook_uris = [HOST]
+      end
+      WebSocketVCR.use_cassette(cassette_path, {erb: {something: 11223344}}) do
+        test_substitution '11223344'
+      end
+      file_path = "#{WebSocketVCR.configuration.cassette_library_dir}#{cassette_path}.yml"
+      expect(File.readlines(file_path).grep(/<%= something %>/).size).to eq(1)
+    end
+
+    it 'with :erb set to {something: world, bar: hello}, it should replace the variables in json cassette' do
+      cassette_path = '/EXPLICIT/some_template'
+      WebSocketVCR.configure do |c|
+        c.hook_uris = [HOST]
+        c.json_cassettes = true
+      end
+      WebSocketVCR.use_cassette(cassette_path, {erb: {something: 'world', bar: 'hello'}}) do
+        test_substitution 'world', 'hello'
+      end
+    end
   end
 end


### PR DESCRIPTION
issue #3 
- `record: :none` option doesn't run the recorder (we don't want to overwrite the templates that uses the ERB)
