### PR TITLE
Reverse substitution

### DIFF
--- a/lib/simple_websocket_vcr.rb
+++ b/lib/simple_websocket_vcr.rb
@@ -74,6 +74,8 @@ module WebSocketVCR
   # @param options [Hash] options for the cassette
   # @option options [Symbol] :record if set to :none there will be no recording
   # @option options [Symbol] :erb a sub-hash with variables used for ERB substitution in given cassette
+  # @option options [Boolean] :reverse_substitution if true, the values of :erb hash will be replaced by their names in
+  #                                                 the cassette. It's turned-off by default.
   def use_cassette(name, options = {})
     fail ArgumentError, '`VCR.use_cassette` requires a block.' unless block_given?
     self.cassette = Cassette.new(name, options)

--- a/lib/simple_websocket_vcr.rb
+++ b/lib/simple_websocket_vcr.rb
@@ -69,9 +69,14 @@ module WebSocketVCR
   def save_session
   end
 
-  def use_cassette(name, _options = {})
+  # Use the specified cassette for either recording the real communication or replaying it during the tests.
+  # @param name [String] the cassette
+  # @param options [Hash] options for the cassette
+  # @option options [Symbol] :record if set to :none there will be no recording
+  # @option options [Symbol] :erb a sub-hash with variables used for ERB substitution in given cassette
+  def use_cassette(name, options = {})
     fail ArgumentError, '`VCR.use_cassette` requires a block.' unless block_given?
-    self.cassette = Cassette.new(name)
+    self.cassette = Cassette.new(name, options)
     yield
     cassette.save
     self.cassette = nil

--- a/lib/simple_websocket_vcr/cassette.rb
+++ b/lib/simple_websocket_vcr/cassette.rb
@@ -29,10 +29,10 @@ module WebSocketVCR
       if recording?
         erb_variables = @options[:reverse_substitution] ? @options[:erb] : nil
         session = if @using_json
-          RecordedJsonSession.new([], erb_variables)
-        else
-          RecordedYamlSession.new([], erb_variables)
-        end
+                    RecordedJsonSession.new([], erb_variables)
+                  else
+                    RecordedYamlSession.new([], erb_variables)
+                  end
         @sessions.push(session)
         @sessions.last
       else

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_yaml_cassette.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_yaml_cassette.yml
@@ -2,7 +2,7 @@
 websocket_interactions:
 - - operation: read
     type: text
-    data: WelcomeResponse={"sessionId":"Wk5AgRVBjxWhBIihLTxsA3IjZkpZoAlhJP6mHsiP"}
+    data: WelcomeResponse={"sessionId":"<%= foobar %>"}
   - operation: write
     data: something_1
   - operation: read

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_other_template.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_other_template.yml
@@ -1,0 +1,7 @@
+---
+websocket_interactions:
+- - operation: read
+    type: text
+    data: <%= something %>={"sessionId":"_5_u_6hSDOVe0LlvGyx32CGR-f98iKwHQtjoQKy8"}
+  - operation: write
+    data: something_1

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.json
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.json
@@ -1,0 +1,13 @@
+[
+  [
+    {
+      "operation": "read",
+      "type": "text",
+      "data": "WelcomeResponse={\"<%= something %>\":\"I_XSiCb1wcQgARIzJ_jRU8k2-kPVblJuNCxhYBnb\"}"
+    },
+    {
+      "operation": "write",
+      "data": "<%= bar %>"
+    }
+  ]
+]

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.yml
@@ -1,0 +1,25 @@
+---
+websocket_interactions:
+- - operation: read
+    type: text
+    data: WelcomeResponse={"<%= something %>":"KOrViCF_93axNx-WyGlhT6yktwqbJIl97mrxQXC5"}
+  - operation: write
+    data: something_1
+  - operation: read
+    type: text
+    data: 'GenericErrorResponse={"errorMessage":"Failed to process message [?]","stackTrace":"java.lang.IllegalArgumentException:
+      Cannot deserialize: [something_1]\n\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\n\tat
+      org.hawkular.cmdgw.api.ApiDeserializer.deserialize(ApiDeserializer.java:84)\n\tat
+      org.hawkular.cmdgw.command.ws.server.AbstractGatewayWebSocket.onMessage(AbstractGatewayWebSocket.java:213)\n\tat
+      sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat
+      sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat
+      java.lang.reflect.Method.invoke(Method.java:497)\n\tat io.undertow.websockets.jsr.annotated.BoundMethod.invoke(BoundMethod.java:87)\n\tat
+      io.undertow.websockets.jsr.annotated.AnnotatedEndpoint$2$1.run(AnnotatedEndpoint.java:150)\n\tat
+      io.undertow.websockets.jsr.ServerWebSocketContainer.invokeEndpointMethod(ServerWebSocketContainer.java:553)\n\tat
+      io.undertow.websockets.jsr.annotated.AnnotatedEndpoint$2.onMessage(AnnotatedEndpoint.java:145)\n\tat
+      io.undertow.websockets.jsr.FrameHandler$7.run(FrameHandler.java:283)\n\tat io.undertow.websockets.jsr.ServerWebSocketContainer.invokeEndpointMethod(ServerWebSocketContainer.java:553)\n\tat
+      io.undertow.websockets.jsr.ServerWebSocketContainer$5.run(ServerWebSocketContainer.java:538)\n\tat
+      io.undertow.websockets.jsr.OrderedExecutor$ExecutorTask.run(OrderedExecutor.java:67)\n\tat
+      java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\n\tat
+      java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\tat
+      java.lang.Thread.run(Thread.java:745)\n"}'

--- a/spec/vcr_spec.rb
+++ b/spec/vcr_spec.rb
@@ -229,7 +229,7 @@ describe 'VCR for WS' do
       prefix = WebSocketVCR.configuration.cassette_library_dir
       cassette_path = '/EXPLICIT/something_nonexistent'
       expect do
-        WebSocketVCR.use_cassette(cassette_path, {record: :none}) do
+        WebSocketVCR.use_cassette(cassette_path, record: :none) do
           fail 'this code should not be reachable'
         end
       end.to raise_error(RuntimeError)
@@ -256,7 +256,7 @@ describe 'VCR for WS' do
       WebSocketVCR.configure do |c|
         c.hook_uris = [HOST]
       end
-      WebSocketVCR.use_cassette(cassette_path, {erb: {something: 11223344}}) do
+      WebSocketVCR.use_cassette(cassette_path, erb: { something: 11_223_344 }) do
         test_substitution '11223344'
       end
       file_path = "#{WebSocketVCR.configuration.cassette_library_dir}#{cassette_path}.yml"
@@ -269,7 +269,7 @@ describe 'VCR for WS' do
         c.hook_uris = [HOST]
         c.json_cassettes = true
       end
-      WebSocketVCR.use_cassette(cassette_path, {erb: {something: 'world', bar: 'hello'}}) do
+      WebSocketVCR.use_cassette(cassette_path, erb: { something: 'world', bar: 'hello' }) do
         test_substitution 'world', 'hello'
       end
     end

--- a/spec/vcr_spec.rb
+++ b/spec/vcr_spec.rb
@@ -256,7 +256,7 @@ describe 'VCR for WS' do
       WebSocketVCR.configure do |c|
         c.hook_uris = [HOST]
       end
-      WebSocketVCR.use_cassette(cassette_path, erb: { something: 11_223_344 }) do
+      WebSocketVCR.use_cassette(cassette_path, erb: { something: 11_223_344 }, record: :none) do
         test_substitution '11223344'
       end
       file_path = "#{WebSocketVCR.configuration.cassette_library_dir}#{cassette_path}.yml"
@@ -272,6 +272,18 @@ describe 'VCR for WS' do
       WebSocketVCR.use_cassette(cassette_path, erb: { something: 'world', bar: 'hello' }) do
         test_substitution 'world', 'hello'
       end
+    end
+
+    it 'with :erb set to {something: 11223344}, and :reverse_substitution it should record the cassette as template' do
+      cassette_path = '/EXPLICIT/some_other_template'
+      WebSocketVCR.configure do |c|
+        c.hook_uris = [HOST]
+      end
+      WebSocketVCR.use_cassette(cassette_path, erb: { something: 'WelcomeResponse' }, reverse_substitution: true) do
+        test_substitution 'unlikely_string'
+      end
+      file_path = "#{WebSocketVCR.configuration.cassette_library_dir}#{cassette_path}.yml"
+      expect(File.readlines(file_path).grep(/<%= something %>/).size).to eq(1)
     end
   end
 end

--- a/spec/vcr_spec.rb
+++ b/spec/vcr_spec.rb
@@ -218,5 +218,60 @@ describe 'VCR for WS' do
         WebSocketVCR.configure { |c| c.hook_uris = ['127.0.0.1:1337'] }
       end.to change { WebSocketVCR.configuration.hook_uris }.from([]).to(['127.0.0.1:1337'])
     end
+
+    it 'has an empty list of hook ports by default' do
+      expect(WebSocketVCR.configuration.hook_uris).to eq([])
+    end
+  end
+
+  context 'with cassette options' do
+    it 'with :record set to :none and no cassette, it should fail' do
+      prefix = WebSocketVCR.configuration.cassette_library_dir
+      cassette_path = '/EXPLICIT/something_nonexistent'
+      expect do
+        WebSocketVCR.use_cassette(cassette_path, {record: :none}) do
+          fail 'this code should not be reachable'
+        end
+      end.to raise_error(RuntimeError)
+      expect(File.exist?(prefix + cassette_path + '.yml')).to be false
+    end
+
+    def test_substitution(text1, text2 = nil)
+      url = "ws://#{HOST}/hawkular/command-gateway/ui/ws"
+      c = WebSocket::Client::Simple.connect url do |client|
+        client.on(:message, once: true) do |msg|
+          expect(msg.data).to include(text1)
+        end
+      end
+      sleep 1 if should_sleep
+      text2 ||= 'something_1'
+      c.send(text2)
+      c.on(:message, once: true) do |msg|
+        expect(msg.data).to include("Cannot deserialize: [#{text2}]")
+      end
+    end
+
+    it 'with :erb set to {something: 11223344}, it should replace the variable in yaml cassette' do
+      cassette_path = '/EXPLICIT/some_template'
+      WebSocketVCR.configure do |c|
+        c.hook_uris = [HOST]
+      end
+      WebSocketVCR.use_cassette(cassette_path, {erb: {something: 11223344}}) do
+        test_substitution '11223344'
+      end
+      file_path = "#{WebSocketVCR.configuration.cassette_library_dir}#{cassette_path}.yml"
+      expect(File.readlines(file_path).grep(/<%= something %>/).size).to eq(1)
+    end
+
+    it 'with :erb set to {something: world, bar: hello}, it should replace the variables in json cassette' do
+      cassette_path = '/EXPLICIT/some_template'
+      WebSocketVCR.configure do |c|
+        c.hook_uris = [HOST]
+        c.json_cassettes = true
+      end
+      WebSocketVCR.use_cassette(cassette_path, {erb: {something: 'world', bar: 'hello'}}) do
+        test_substitution 'world', 'hello'
+      end
+    end
   end
 end


### PR DESCRIPTION
if the `erb: {key_x: 'value_x'}, reverse_substitution: true` options are used, the library will look into the data that is about to stored in the cassette and if there is a string `value_x`, it's replaced with `<%= key_x %>`.

The idea here is not to over-write the cassettes that are used as templates.
