### PR TITLE
Test against ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 2.3
   - 2.4
+  - 2.5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,11 @@
 require 'coveralls'
 Coveralls.wear!
 
+# https://stackoverflow.com/a/9095369/10513533
+# Without this, exceptions coming from code run in threads won't fail tests.
+# For example, WebSocketVCR::RecordableWebsocketClient uses threads.
+Thread.abort_on_exception = true
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.order = 'random'


### PR DESCRIPTION
I'm seeing some issues on ruby 2.5. When I run the tests with ruby 2.4, I get the following:

![ruby-2 4](https://user-images.githubusercontent.com/3466499/56850398-fb96e500-68cf-11e9-8e36-9f3e64ba8bd7.PNG)

And when I run them with ruby 2.5, I get the following:

![ruby-2 5](https://user-images.githubusercontent.com/3466499/56850399-06ea1080-68d0-11e9-99d6-75b0471edc47.PNG)

![ruby-2 5-02](https://user-images.githubusercontent.com/3466499/56850413-43b60780-68d0-11e9-8874-314674a400c7.PNG)


I'm running the tests in docker, and perhaps something is wrong with my ruby 2.5 dockerfile, so I'm curious what travis will discover when it runs these tests on ruby 2.5