### PR TITLE
Distinguish which kind of events we record

### DIFF
--- a/lib/simple_websocket_vcr/cassette.rb
+++ b/lib/simple_websocket_vcr/cassette.rb
@@ -121,11 +121,12 @@ module WebSocketVCR
   end
 
   class RecordEntry
-    attr_accessor :operation, :type, :data
+    attr_accessor :operation, :event, :type, :data
 
     def self.parse(obj, erb_variables = nil)
       record_entry = RecordEntry.new
       record_entry.operation = obj['operation']
+      record_entry.event = obj['event'] if obj['event']
       record_entry.type = obj['type'] if obj['type']
       record_entry.data = obj['data'] if obj['data']
 

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_cassette_should_be_re-recorded.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_cassette_should_be_re-recorded.yml
@@ -1,11 +1,14 @@
 ---
 websocket_interactions:
 - - operation: read
+    event: message
     type: text
     data: WelcomeResponse={"sessionId":"_Q8LZN4jeyX27Qb2qjiz_3HR9Ckoa1S-pHMaJi9q"}
   - operation: write
+    event: send
     data: something_1
   - operation: read
+    event: message
     type: text
     data: 'GenericErrorResponse={"errorMessage":"Failed to process message [?]","stackTrace":"java.lang.IllegalArgumentException:
       Cannot deserialize: [something_1]\n\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\n\tat
@@ -24,8 +27,10 @@ websocket_interactions:
       java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\tat
       java.lang.Thread.run(Thread.java:745)\n"}'
   - operation: write
+    event: send
     data: something_2
   - operation: read
+    event: message
     type: text
     data: 'GenericErrorResponse={"errorMessage":"Failed to process message [?]","stackTrace":"java.lang.IllegalArgumentException:
       Cannot deserialize: [something_2]\n\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\n\tat
@@ -43,4 +48,5 @@ websocket_interactions:
       java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\n\tat
       java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\tat
       java.lang.Thread.run(Thread.java:745)\n"}'
-  - operation: close
+  - operation: write
+    event: close

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_json_cassette.json
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_json_cassette.json
@@ -2,29 +2,35 @@
   [
     {
       "operation": "read",
+      "event": "message",
       "type": "text",
       "data": "WelcomeResponse={\"sessionId\":\"6lLLtFyPAUmpeh3JiSUW3b1D1YN6FTLGHc2Yt8dI\"}"
     },
     {
       "operation": "write",
+      "event": "send",
       "data": "something_1"
     },
     {
       "operation": "read",
+      "event": "message",
       "type": "text",
       "data": "GenericErrorResponse={\"errorMessage\":\"Failed to process message [?]\",\"stackTrace\":\"java.lang.IllegalArgumentException: Cannot deserialize: [something_1]\\n\\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\\n\\tat org.hawkular.cmdgw.api.ApiDeserializer.deserialize(ApiDeserializer.java:84)\\n\\tat org.hawkular.cmdgw.command.ws.server.AbstractGatewayWebSocket.onMessage(AbstractGatewayWebSocket.java:213)\\n\\tat sun.reflect.GeneratedMethodAccessor686.invoke(Unknown Source)\\n\\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\n\\tat java.lang.reflect.Method.invoke(Method.java:497)\\n\\tat io.undertow.websockets.jsr.annotated.BoundMethod.invoke(BoundMethod.java:87)\\n\\tat io.undertow.websockets.jsr.annotated.AnnotatedEndpoint$2$1.run(AnnotatedEndpoint.java:150)\\n\\tat io.undertow.websockets.jsr.ServerWebSocketContainer.invokeEndpointMethod(ServerWebSocketContainer.java:553)\\n\\tat io.undertow.websockets.jsr.annotated.AnnotatedEndpoint$2.onMessage(AnnotatedEndpoint.java:145)\\n\\tat io.undertow.websockets.jsr.FrameHandler$7.run(FrameHandler.java:283)\\n\\tat io.undertow.websockets.jsr.ServerWebSocketContainer.invokeEndpointMethod(ServerWebSocketContainer.java:553)\\n\\tat io.undertow.websockets.jsr.ServerWebSocketContainer$5.run(ServerWebSocketContainer.java:538)\\n\\tat io.undertow.websockets.jsr.OrderedExecutor$ExecutorTask.run(OrderedExecutor.java:67)\\n\\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\\n\\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\\n\\tat java.lang.Thread.run(Thread.java:745)\\n\"}"
     },
     {
       "operation": "write",
+      "event": "send",
       "data": "something_2"
     },
     {
       "operation": "read",
+      "event": "message",
       "type": "text",
       "data": "GenericErrorResponse={\"errorMessage\":\"Failed to process message [?]\",\"stackTrace\":\"java.lang.IllegalArgumentException: Cannot deserialize: [something_2]\\n\\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\\n\\tat org.hawkular.cmdgw.api.ApiDeserializer.deserialize(ApiDeserializer.java:84)\\n\\tat org.hawkular.cmdgw.command.ws.server.AbstractGatewayWebSocket.onMessage(AbstractGatewayWebSocket.java:213)\\n\\tat sun.reflect.GeneratedMethodAccessor686.invoke(Unknown Source)\\n\\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\n\\tat java.lang.reflect.Method.invoke(Method.java:497)\\n\\tat io.undertow.websockets.jsr.annotated.BoundMethod.invoke(BoundMethod.java:87)\\n\\tat io.undertow.websockets.jsr.annotated.AnnotatedEndpoint$2$1.run(AnnotatedEndpoint.java:150)\\n\\tat io.undertow.websockets.jsr.ServerWebSocketContainer.invokeEndpointMethod(ServerWebSocketContainer.java:553)\\n\\tat io.undertow.websockets.jsr.annotated.AnnotatedEndpoint$2.onMessage(AnnotatedEndpoint.java:145)\\n\\tat io.undertow.websockets.jsr.FrameHandler$7.run(FrameHandler.java:283)\\n\\tat io.undertow.websockets.jsr.ServerWebSocketContainer.invokeEndpointMethod(ServerWebSocketContainer.java:553)\\n\\tat io.undertow.websockets.jsr.ServerWebSocketContainer$5.run(ServerWebSocketContainer.java:538)\\n\\tat io.undertow.websockets.jsr.OrderedExecutor$ExecutorTask.run(OrderedExecutor.java:67)\\n\\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\\n\\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\\n\\tat java.lang.Thread.run(Thread.java:745)\\n\"}"
     },
     {
-      "operation": "close"
+      "operation": "write",
+      "event": "close"
     }
   ]
 ]

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_yaml_cassette.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_explicitly_specified_yaml_cassette.yml
@@ -1,11 +1,14 @@
 ---
 websocket_interactions:
 - - operation: read
+    event: message
     type: text
     data: WelcomeResponse={"sessionId":"<%= foobar %>"}
   - operation: write
+    event: send
     data: something_1
   - operation: read
+    event: message
     type: text
     data: 'GenericErrorResponse={"errorMessage":"Failed to process message [?]","stackTrace":"java.lang.IllegalArgumentException:
       Cannot deserialize: [something_1]\n\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\n\tat
@@ -23,8 +26,10 @@ websocket_interactions:
       java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\tat
       java.lang.Thread.run(Thread.java:745)\n"}'
   - operation: write
+    event: send
     data: something_2
   - operation: read
+    event: message
     type: text
     data: 'GenericErrorResponse={"errorMessage":"Failed to process message [?]","stackTrace":"java.lang.IllegalArgumentException:
       Cannot deserialize: [something_2]\n\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\n\tat
@@ -41,4 +46,5 @@ websocket_interactions:
       java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\n\tat
       java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\tat
       java.lang.Thread.run(Thread.java:745)\n"}'
-  - operation: close
+  - operation: write
+    event: close

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_other_template.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_other_template.yml
@@ -1,7 +1,9 @@
 ---
 websocket_interactions:
 - - operation: read
+    event: message
     type: text
     data: <%= something %>={"sessionId":"_5_u_6hSDOVe0LlvGyx32CGR-f98iKwHQtjoQKy8"}
   - operation: write
+    event: send
     data: something_1

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.json
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.json
@@ -2,11 +2,13 @@
   [
     {
       "operation": "read",
+      "event": "message",
       "type": "text",
       "data": "WelcomeResponse={\"<%= something %>\":\"I_XSiCb1wcQgARIzJ_jRU8k2-kPVblJuNCxhYBnb\"}"
     },
     {
       "operation": "write",
+      "event": "send",
       "data": "<%= bar %>"
     }
   ]

--- a/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.yml
+++ b/spec/fixtures/vcr_cassettes/EXPLICIT/some_template.yml
@@ -1,11 +1,14 @@
 ---
 websocket_interactions:
 - - operation: read
+    event: message
     type: text
     data: WelcomeResponse={"<%= something %>":"KOrViCF_93axNx-WyGlhT6yktwqbJIl97mrxQXC5"}
   - operation: write
+    event: send
     data: something_1
   - operation: read
+    event: message
     type: text
     data: 'GenericErrorResponse={"errorMessage":"Failed to process message [?]","stackTrace":"java.lang.IllegalArgumentException:
       Cannot deserialize: [something_1]\n\tat org.hawkular.cmdgw.api.ApiDeserializer.fromHawkularFormat(ApiDeserializer.java:68)\n\tat

--- a/spec/fixtures/vcr_cassettes/VCR_for_WS/should_record_also_the_outgoing_communication.yml
+++ b/spec/fixtures/vcr_cassettes/VCR_for_WS/should_record_also_the_outgoing_communication.yml
@@ -1,11 +1,15 @@
 ---
 websocket_interactions:
 - - operation: read
+    event: message
     type: text
     data: WelcomeResponse={"sessionId":"XQVVtE53wxz1lmMsqz2TbmR68ilFzDxLOOpkKGpd"}
   - operation: write
+    send: message
     data: something 1
   - operation: write
+    send: message
     data: something 2
   - operation: write
+    send: message
     data: something 3

--- a/spec/fixtures/vcr_cassettes/VCR_for_WS/should_record_the_closing_event(json).json
+++ b/spec/fixtures/vcr_cassettes/VCR_for_WS/should_record_the_closing_event(json).json
@@ -2,11 +2,13 @@
   [
     {
       "operation": "read",
+      "event": "message",
       "type": "text",
       "data": "WelcomeResponse={\"sessionId\":\"rfynzN_MQHaFvhedHpqiQj1zFo0hBHsiICU4pmX-\"}"
     },
     {
-      "operation": "close"
+      "operation": "write",
+      "event": "close"
     }
   ]
 ]

--- a/spec/fixtures/vcr_cassettes/VCR_for_WS/should_record_the_closing_event(yaml).yml
+++ b/spec/fixtures/vcr_cassettes/VCR_for_WS/should_record_the_closing_event(yaml).yml
@@ -1,6 +1,8 @@
 ---
 websocket_interactions:
 - - operation: read
+    event: message
     type: text
     data: WelcomeResponse={"sessionId":"3CEro9B5w8IUD4DAaVxRocyKm-rMVXLMlECNwfgD"}
-  - operation: close
+  - operation: write
+    event: close

--- a/spec/fixtures/vcr_cassettes/VCR_for_WS/should_record_the_very_first_message_caught_on_the_client_yielded_by_the_connect_method.yml
+++ b/spec/fixtures/vcr_cassettes/VCR_for_WS/should_record_the_very_first_message_caught_on_the_client_yielded_by_the_connect_method.yml
@@ -1,5 +1,6 @@
 ---
 websocket_interactions:
 - - operation: read
+    event: message
     type: text
     data: WelcomeResponse={"sessionId":"g-YqmCVcqkDqG7KkgzSzhd0qbeoM0fsVheOJ5jx8"}

--- a/spec/fixtures/vcr_cassettes/VCR_for_WS/when_server_closes_connection_works.yml
+++ b/spec/fixtures/vcr_cassettes/VCR_for_WS/when_server_closes_connection_works.yml
@@ -1,0 +1,34 @@
+---
+websocket_interactions:
+- - operation: read
+    event: open
+  - operation: write
+    event: send
+    data: hello
+  - operation: write
+    event: send
+    data: how
+  - operation: write
+    event: send
+    data: are
+  - operation: write
+    event: send
+    data: you
+  - operation: read
+    event: message
+    type: text
+    data: hello
+  - operation: read
+    event: message
+    type: text
+    data: how
+  - operation: read
+    event: message
+    type: text
+    data: are
+  - operation: read
+    event: message
+    type: text
+    data: you
+  - operation: read
+    event: close

--- a/spec/fixtures/vcr_cassettes/VCR_for_WS/with_multiple_kinds_of_events_works.yml
+++ b/spec/fixtures/vcr_cassettes/VCR_for_WS/with_multiple_kinds_of_events_works.yml
@@ -1,0 +1,36 @@
+---
+websocket_interactions:
+- - operation: read
+    event: open
+  - operation: write
+    event: send
+    data: hello
+  - operation: write
+    event: send
+    data: how
+  - operation: write
+    event: send
+    data: are
+  - operation: write
+    event: send
+    data: you
+  - operation: read
+    event: message
+    type: text
+    data: hello
+  - operation: read
+    event: message
+    type: text
+    data: how
+  - operation: read
+    event: message
+    type: text
+    data: are
+  - operation: read
+    event: message
+    type: text
+    data: you
+  - operation: write
+    event: close
+  - operation: read
+    event: close


### PR DESCRIPTION
Hi @Jiri-Kremser, thanks for this library, I'm finding it quite useful in an app I'm working on.

In my app -- in addition to the `message` event -- I record `open` and `close` events. I've discovered that this library replays all of its records as whatever kind of event it captured first -- in my case the `open` event. So if I recorded an `open` event, three `message` events, and a `close` event, this library replays them all as `open` events. This problem is caused by [this code](https://github.com/Jiri-Kremser/simple-websocket-vcr/blob/1d8d6adb52248b8fbc08da7b87be19d11bc6e3f1/lib/simple_websocket_vcr/recordable_websocket_client.rb#L78-L115):
```rb
def _read(event, params, &_block)
  if @live
    # some stuff
  else
    wait_for_reads(event) unless @thread && @thread.alive?
  end
end

def wait_for_reads(event)
  @thread = Thread.new do
    while @open && !@session.empty?
      begin
        if @session.head.operation == 'read'
          # some stuff
          emit(event, data)
          # some stuff
        end
      end
    end
  end
end
```
When it replays its first record, the `event` it calls `_read` with is the `event` it uses in every record that `wait_for_reads` replays, no matter which `event` that record actually had.

My fix explicitly records and replays `event` values for each record. It is not a backwards compatible change, because formerly recorded sessions won't have `event` values saved, and will crash like so:
```
     NoMethodError:
       undefined method `to_sym' for nil:NilClass
     # ./lib/websocket-client-simple/lib/event_emitter/lib/event_emitter/emitter.rb:47:in `emit'
     # ./lib/simple_websocket_vcr/recordable_websocket_client.rb:40:in `emit'
     # ./lib/simple_websocket_vcr/recordable_websocket_client.rb:117:in `block in wait_for_reads'
```
I can explore how to make this fix backwards compatible is this is something you're interested in.